### PR TITLE
seed_vaultsをdrizzle-kitを使用してdrizle ORMの管理下に置く

### DIFF
--- a/axis-api/migrations/0001_seed_vaults.sql
+++ b/axis-api/migrations/0001_seed_vaults.sql
@@ -1,0 +1,60 @@
+INSERT INTO vaults (id, name, symbol, description, creator, strategy_type, management_fee, min_liquidity, composition, image_url, tvl, apy, created_at) VALUES 
+-- 1. Majors
+('v-001', 'Solana Blue Chip', 'BLUE', 'Exposure to the top ecosystem heavyweights: SOL, BTC, and ETH.', 'Axis Team', 'yield_max', 0.95, 1000, '[{"token":{"symbol":"SOL","name":"Wrapped SOL","logoURI":"https://assets.coingecko.com/coins/images/4128/large/solana.png"},"weight":50},{"token":{"symbol":"WBTC","name":"Wrapped Bitcoin","logoURI":"https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png"},"weight":25},{"token":{"symbol":"WETH","name":"Wrapped Ethereum","logoURI":"https://assets.coingecko.com/coins/images/279/large/ethereum.png"},"weight":25}]', 'https://assets.coingecko.com/coins/images/4128/large/solana.png', 5420000, 8.5, strftime('%s', 'now') - 800000),
+
+-- 2. Meme
+('v-002', 'Meme Supercycle', 'MEME', 'High beta exposure to the leading memecoins on Solana.', 'degen_whale.sol', 'momentum', 1.5, 500, '[{"token":{"symbol":"WIF","name":"dogwifhat","logoURI":"https://assets.coingecko.com/coins/images/33566/large/dogwifhat.jpg"},"weight":40},{"token":{"symbol":"BONK","name":"Bonk","logoURI":"https://assets.coingecko.com/coins/images/28600/large/bonk.jpg"},"weight":40},{"token":{"symbol":"POPCAT","name":"Popcat","logoURI":"https://s2.coinmarketcap.com/static/img/coins/64x64/28782.png"},"weight":20}]', 'https://assets.coingecko.com/coins/images/33566/large/dogwifhat.jpg', 1250000, 420.69, strftime('%s', 'now') - 40000),
+
+-- 3. LST
+('v-003', 'Liquid Staking Max', 'LST', 'Optimized yield from leading liquid staking tokens.', 'Axis Team', 'yield_max', 0.5, 10000, '[{"token":{"symbol":"jitoSOL","name":"Jito Staked SOL","logoURI":"https://s2.coinmarketcap.com/static/img/coins/64x64/22533.png"},"weight":50},{"token":{"symbol":"mSOL","name":"Marinade Staked SOL","logoURI":"https://assets.coingecko.com/coins/images/17752/large/mSOL.png"},"weight":30},{"token":{"symbol":"bSOL","name":"BlazeStake","logoURI":"https://s2.coinmarketcap.com/static/img/coins/64x64/28862.png"},"weight":20}]', 'https://s2.coinmarketcap.com/static/img/coins/64x64/22533.png', 8900000, 7.8, strftime('%s', 'now') - 1200000),
+
+-- 4. DeFi
+('v-004', 'Solana DeFi Core', 'DEFI', 'Governance tokens of the premier decentralized exchanges.', 'ProtocolDAO', 'rebalance', 1.0, 100, '[{"token":{"symbol":"JUP","name":"Jupiter","logoURI":"https://static.jup.ag/jup/icon.png"},"weight":40},{"token":{"symbol":"RAY","name":"Raydium","logoURI":"https://assets.coingecko.com/coins/images/13928/large/PSigc4ie_400x400.jpg"},"weight":30},{"token":{"symbol":"ORCA","name":"Orca","logoURI":"https://assets.coingecko.com/coins/images/17547/large/Orca_Logo.png"},"weight":30}]', 'https://static.jup.ag/jup/icon.png', 320000, 14.2, strftime('%s', 'now') - 600000),
+
+-- 5. DePIN
+('v-005', 'DePIN Infrastructure', 'PIN', 'Physical infrastructure networks powered by Solana.', 'HNT_Maxi', 'yield_max', 1.2, 500, '[{"token":{"symbol":"RENDER","name":"Render","logoURI":"https://assets.coingecko.com/coins/images/11636/large/rndr.png"},"weight":60},{"token":{"symbol":"HNT","name":"Helium","logoURI":"https://assets.coingecko.com/coins/images/4284/large/Helium_HNT.png"},"weight":40}]', 'https://assets.coingecko.com/coins/images/11636/large/rndr.png', 450000, 9.1, strftime('%s', 'now') - 300000),
+
+-- 6. Stable
+('v-006', 'Stable Yield Agg', 'USD+', 'Low risk, stablecoin yield farming strategy.', 'Axis Team', 'yield_max', 0.1, 50000, '[{"token":{"symbol":"USDC","name":"USD Coin","logoURI":"https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png"},"weight":50},{"token":{"symbol":"USDT","name":"Tether","logoURI":"https://assets.coingecko.com/coins/images/325/large/Tether.png"},"weight":50}]', 'https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png', 12000000, 4.5, strftime('%s', 'now') - 2000000),
+
+-- 7. Community
+('v-007', 'Dog Coin Index', 'DOG', 'Woof woof.', 'shib_lover', 'momentum', 2.0, 100, '[{"token":{"symbol":"BONK","name":"Bonk","logoURI":"https://assets.coingecko.com/coins/images/28600/large/bonk.jpg"},"weight":50},{"token":{"symbol":"WIF","name":"dogwifhat","logoURI":"https://assets.coingecko.com/coins/images/33566/large/dogwifhat.jpg"},"weight":50}]', 'https://assets.coingecko.com/coins/images/28600/large/bonk.jpg', 54000, 88.8, strftime('%s', 'now') - 10000),
+
+-- 8. Mixed
+('v-008', 'Solana Ecosystem', 'ECO', 'Broad exposure to the entire Solana economy.', 'Axis Team', 'rebalance', 0.8, 1000, '[{"token":{"symbol":"SOL","name":"Wrapped SOL","logoURI":"https://assets.coingecko.com/coins/images/4128/large/solana.png"},"weight":40},{"token":{"symbol":"JUP","name":"Jupiter","logoURI":"https://static.jup.ag/jup/icon.png"},"weight":20},{"token":{"symbol":"PYTH","name":"Pyth","logoURI":"https://assets.coingecko.com/coins/images/31924/large/pyth.png"},"weight":20},{"token":{"symbol":"WIF","name":"WIF","logoURI":"https://assets.coingecko.com/coins/images/33566/large/dogwifhat.jpg"},"weight":20}]', 'https://assets.coingecko.com/coins/images/4128/large/solana.png', 2100000, 18.5, strftime('%s', 'now') - 900000),
+
+-- 9. Oracle
+('v-009', 'Oracle Plays', 'DATA', 'Betting on the data layer.', 'data_nerd', 'yield_max', 1.0, 500, '[{"token":{"symbol":"PYTH","name":"Pyth Network","logoURI":"https://assets.coingecko.com/coins/images/31924/large/pyth.png"},"weight":100}]', 'https://assets.coingecko.com/coins/images/31924/large/pyth.png', 120000, 11.2, strftime('%s', 'now') - 500000),
+
+-- 10. BTC on Sol
+('v-010', 'Bitcoin Maxi', 'WBTC', 'Just Bitcoin, but on Solana rails.', 'satoshi_fan', 'yield_max', 0.5, 1000, '[{"token":{"symbol":"WBTC","name":"Wrapped Bitcoin","logoURI":"https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png"},"weight":100}]', 'https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png', 3400000, 2.1, strftime('%s', 'now') - 1500000),
+
+-- 11. ETH on Sol
+('v-011', 'Ether Bridge', 'WETH', 'Ethereum liquidity on Solana.', 'vitalik_fan', 'yield_max', 0.5, 1000, '[{"token":{"symbol":"WETH","name":"Wrapped Ethereum","logoURI":"https://assets.coingecko.com/coins/images/279/large/ethereum.png"},"weight":100}]', 'https://assets.coingecko.com/coins/images/279/large/ethereum.png', 2800000, 3.4, strftime('%s', 'now') - 1400000),
+
+-- 12. Degen
+('v-012', '1000x or Bust', 'YOLO', 'Extremely high risk meme strategy.', 'gambler_pro', 'momentum', 5.0, 10, '[{"token":{"symbol":"POPCAT","name":"Popcat","logoURI":"https://s2.coinmarketcap.com/static/img/coins/64x64/28782.png"},"weight":80},{"token":{"symbol":"SOL","name":"SOL","logoURI":"https://assets.coingecko.com/coins/images/4128/large/solana.png"},"weight":20}]', 'https://s2.coinmarketcap.com/static/img/coins/64x64/28782.png', 8000, 999.0, strftime('%s', 'now') - 5000),
+
+-- 13. Jupiter Eco
+('v-013', 'Jupiter Ecosystem', 'JUP+', 'Everything related to the Jupiter exchange.', 'Jup_DAO', 'rebalance', 0.9, 500, '[{"token":{"symbol":"JUP","name":"Jupiter","logoURI":"https://static.jup.ag/jup/icon.png"},"weight":70},{"token":{"symbol":"SOL","name":"SOL","logoURI":"https://assets.coingecko.com/coins/images/4128/large/solana.png"},"weight":30}]', 'https://static.jup.ag/jup/icon.png', 750000, 15.6, strftime('%s', 'now') - 700000),
+
+-- 14. Conservative
+('v-014', 'Safe Harbor', 'SAFE', 'Heavy stablecoin allocation with minor crypto exposure.', 'Grandma_Invests', 'yield_max', 0.2, 5000, '[{"token":{"symbol":"USDC","name":"USD Coin","logoURI":"https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png"},"weight":80},{"token":{"symbol":"SOL","name":"SOL","logoURI":"https://assets.coingecko.com/coins/images/4128/large/solana.png"},"weight":20}]', 'https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png', 4500000, 6.2, strftime('%s', 'now') - 1800000),
+
+-- 15. Aggressive Growth
+('v-015', 'Aggressive Growth', 'GROW', 'Mid-cap tokens with high upside potential.', 'Axis Team', 'rebalance', 1.1, 1000, '[{"token":{"symbol":"RENDER","name":"Render","logoURI":"https://assets.coingecko.com/coins/images/11636/large/rndr.png"},"weight":33},{"token":{"symbol":"HNT","name":"Helium","logoURI":"https://assets.coingecko.com/coins/images/4284/large/Helium_HNT.png"},"weight":33},{"token":{"symbol":"PYTH","name":"Pyth","logoURI":"https://assets.coingecko.com/coins/images/31924/large/pyth.png"},"weight":34}]', 'https://assets.coingecko.com/coins/images/4284/large/Helium_HNT.png', 670000, 22.4, strftime('%s', 'now') - 450000),
+
+-- 16. Cat Coins
+('v-016', 'Cat Coins Only', 'MEOW', 'Cats rule the internet.', 'cat_lover', 'momentum', 2.0, 100, '[{"token":{"symbol":"POPCAT","name":"Popcat","logoURI":"https://s2.coinmarketcap.com/static/img/coins/64x64/28782.png"},"weight":100}]', 'https://s2.coinmarketcap.com/static/img/coins/64x64/28782.png', 42000, 150.5, strftime('%s', 'now') - 20000),
+
+-- 17. Sol Sol Sol
+('v-017', 'Pure Solana', 'SOL', '100% SOL, automated yield strategies.', 'Axis Team', 'yield_max', 0.5, 1000, '[{"token":{"symbol":"SOL","name":"Wrapped SOL","logoURI":"https://assets.coingecko.com/coins/images/4128/large/solana.png"},"weight":100}]', 'https://assets.coingecko.com/coins/images/4128/large/solana.png', 15000000, 7.2, strftime('%s', 'now') - 2500000),
+
+-- 18. New Gen
+('v-018', 'Next Gen', 'NEXT', 'New tokens listed in the last 3 months.', 'trend_spotter', 'rebalance', 1.5, 500, '[{"token":{"symbol":"WIF","name":"dogwifhat","logoURI":"https://assets.coingecko.com/coins/images/33566/large/dogwifhat.jpg"},"weight":50},{"token":{"symbol":"JUP","name":"Jupiter","logoURI":"https://static.jup.ag/jup/icon.png"},"weight":50}]', 'https://assets.coingecko.com/coins/images/33566/large/dogwifhat.jpg', 330000, 45.0, strftime('%s', 'now') - 100000),
+
+-- 19. Whale Watch
+('v-019', 'Whale Copycat', 'WHALE', 'Following the top wallets on-chain.', 'whale_alert', 'yield_max', 1.0, 5000, '[{"token":{"symbol":"SOL","name":"SOL","logoURI":"https://assets.coingecko.com/coins/images/4128/large/solana.png"},"weight":60},{"token":{"symbol":"USDC","name":"USDC","logoURI":"https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png"},"weight":40}]', 'https://assets.coingecko.com/coins/images/4128/large/solana.png', 2800000, 8.9, strftime('%s', 'now') - 850000),
+
+-- 20. Momentum
+('v-020', 'Momentum Alpha', 'ALPHA', 'Algorithmic momentum trading.', 'quant_fund', 'momentum', 2.0, 10000, '[{"token":{"symbol":"SOL","name":"SOL","logoURI":"https://assets.coingecko.com/coins/images/4128/large/solana.png"},"weight":50},{"token":{"symbol":"BONK","name":"Bonk","logoURI":"https://assets.coingecko.com/coins/images/28600/large/bonk.jpg"},"weight":50}]', 'https://assets.coingecko.com/coins/images/13928/large/PSigc4ie_400x400.jpg', 950000, 32.1, strftime('%s', 'now') - 30000);

--- a/axis-api/migrations/meta/0001_snapshot.json
+++ b/axis-api/migrations/meta/0001_snapshot.json
@@ -1,0 +1,715 @@
+{
+  "id": "4a6d6a33-cef1-401c-9e11-3fe7c88bec25",
+  "prevId": "561f8c75-31ce-44b2-b31c-47737aa93c8f",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "invites": {
+      "name": "invites",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by_user_id": {
+          "name": "used_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategies": {
+      "name": "strategies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_pubkey": {
+          "name": "owner_pubkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jito_bundle_id": {
+          "name": "jito_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_deposited": {
+          "name": "total_deposited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_deployment_baseline": {
+      "name": "strategy_deployment_baseline",
+      "columns": {
+        "strategy_id": {
+          "name": "strategy_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "baseline_ts_bucket_utc": {
+          "name": "baseline_ts_bucket_utc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "baseline_price": {
+          "name": "baseline_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "baseline_confidence": {
+          "name": "baseline_confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_price_snapshots": {
+      "name": "strategy_price_snapshots",
+      "columns": {
+        "strategy_id": {
+          "name": "strategy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ts_bucket_utc": {
+          "name": "ts_bucket_utc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index_price": {
+          "name": "index_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prices_json": {
+          "name": "prices_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weights_json": {
+          "name": "weights_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_json": {
+          "name": "source_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "strategy_price_snapshots_strategy_id_ts_bucket_utc_pk": {
+          "columns": [
+            "strategy_id",
+            "ts_bucket_utc"
+          ],
+          "name": "strategy_price_snapshots_strategy_id_ts_bucket_utc_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "twitter_id": {
+          "name": "twitter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_code_used": {
+          "name": "invite_code_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_code": {
+          "name": "otp_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_expires": {
+          "name": "otp_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_faucet_at": {
+          "name": "last_faucet_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_invested_usd": {
+          "name": "total_invested_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_snapshot_at": {
+          "name": "last_snapshot_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_wallet_address_unique": {
+          "name": "users_wallet_address_unique",
+          "columns": [
+            "wallet_address"
+          ],
+          "isUnique": true
+        },
+        "users_invite_code_unique": {
+          "name": "users_invite_code_unique",
+          "columns": [
+            "invite_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vaults": {
+      "name": "vaults",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_type": {
+          "name": "strategy_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "management_fee": {
+          "name": "management_fee",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_liquidity": {
+          "name": "min_liquidity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "composition": {
+          "name": "composition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tvl": {
+          "name": "tvl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "apy": {
+          "name": "apy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watchlist": {
+      "name": "watchlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "strategy_id": {
+          "name": "strategy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xp_ledger": {
+      "name": "xp_ledger",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_pubkey": {
+          "name": "user_pubkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_id": {
+          "name": "related_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xp_rates": {
+      "name": "xp_rates",
+      "columns": {
+        "strategy_id": {
+          "name": "strategy_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_rate": {
+          "name": "base_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xp_snapshots": {
+      "name": "xp_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_pubkey": {
+          "name": "user_pubkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_id": {
+          "name": "strategy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capped_usd": {
+          "name": "capped_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_processed": {
+          "name": "is_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/axis-api/migrations/meta/_journal.json
+++ b/axis-api/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1772006292250,
       "tag": "0000_superb_master_mold",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1772086518350,
+      "tag": "0001_seed_vaults",
+      "breakpoints": true
     }
   ]
 }

--- a/axis-api/package.json
+++ b/axis-api/package.json
@@ -22,6 +22,8 @@
     "satori": "^0.19.1"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "^12.6.2",
     "drizzle-kit": "^0.31.9",
     "tsx": "^4.21.0",
     "wrangler": "^4.60.0"

--- a/axis-api/package.json
+++ b/axis-api/package.json
@@ -22,8 +22,6 @@
     "satori": "^0.19.1"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13",
-    "better-sqlite3": "^12.6.2",
     "drizzle-kit": "^0.31.9",
     "tsx": "^4.21.0",
     "wrangler": "^4.60.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
         version: 17.2.4
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1
+        version: 0.45.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)
       hono:
         specifier: ^4.11.9
         version: 4.11.9
@@ -266,6 +266,12 @@ importers:
         specifier: ^0.19.1
         version: 0.19.1
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      better-sqlite3:
+        specifier: ^12.6.2
+        version: 12.6.2
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.9
@@ -4856,6 +4862,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -5538,6 +5547,10 @@ packages:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
 
+  better-sqlite3@12.6.2:
+    resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
   big-integer@1.6.36:
     resolution: {integrity: sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==}
     engines: {node: '>=0.6'}
@@ -5560,6 +5573,9 @@ packages:
 
   bitcoin-ops@1.4.1:
     resolution: {integrity: sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   blake-hash@2.0.0:
     resolution: {integrity: sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w==}
@@ -5753,6 +5769,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -6094,6 +6113,10 @@ packages:
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -6555,6 +6578,10 @@ packages:
   exenv@1.2.2:
     resolution: {integrity: sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expo-asset@12.0.12:
     resolution: {integrity: sha512-CsXFCQbx2fElSMn0lyTdRIyKlSXOal6ilLJd+yeZ6xaC7I9AICQgscY5nj0QcwgA+KYYCCEQEBndMsmj7drOWQ==}
     peerDependencies:
@@ -6772,6 +6799,9 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -6824,6 +6854,9 @@ packages:
   getenv@2.0.0:
     resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
     engines: {node: '>=6'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -7600,6 +7633,10 @@ packages:
     resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
     engines: {node: '>=4'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   miniflare@4.20260219.0:
     resolution: {integrity: sha512-EIb5wXbWUnnC60XU2aiFOPNd4fgTXzECkwRSOXZ1vdcY9WZaEE9rVf+h+Apw+WkOHRkp3Dr9/ZhQ5y1R+9iZ4Q==}
     engines: {node: '>=18.0.0'}
@@ -7641,6 +7678,9 @@ packages:
       typescript:
         optional: true
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -7675,6 +7715,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -7691,6 +7734,10 @@ packages:
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
+  node-abi@3.87.0:
+    resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
+    engines: {node: '>=10'}
 
   node-addon-api@2.0.2:
     resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
@@ -8100,6 +8147,12 @@ packages:
 
   preact@10.28.2:
     resolution: {integrity: sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -8680,6 +8733,12 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-plist@1.3.1:
     resolution: {integrity: sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==}
 
@@ -8904,6 +8963,13 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
@@ -9032,6 +9098,9 @@ packages:
 
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -16219,6 +16288,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.6
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.0.10
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 25.0.10
@@ -18258,6 +18331,11 @@ snapshots:
     dependencies:
       open: 8.4.2
 
+  better-sqlite3@12.6.2:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   big-integer@1.6.36: {}
 
   big.js@6.2.2: {}
@@ -18275,6 +18353,12 @@ snapshots:
   bip66@2.0.0: {}
 
   bitcoin-ops@1.4.1: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   blake-hash@2.0.0:
     dependencies:
@@ -18513,6 +18597,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@1.1.4: {}
 
   chownr@3.0.0: {}
 
@@ -18848,6 +18934,10 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -18940,7 +19030,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1: {}
+  drizzle-orm@0.45.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2):
+    optionalDependencies:
+      '@types/better-sqlite3': 7.6.13
+      better-sqlite3: 12.6.2
 
   dunder-proto@1.0.1:
     dependencies:
@@ -19308,6 +19401,8 @@ snapshots:
 
   exenv@1.2.2: {}
 
+  expand-template@2.0.3: {}
+
   expo-asset@12.0.12(expo@54.0.33(@babel/core@7.28.6)(bufferutil@4.1.0)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.2.10)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.2.10)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4):
     dependencies:
       '@expo/image-utils': 0.8.8
@@ -19561,6 +19656,8 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fs-constants@1.0.0: {}
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
@@ -19605,6 +19702,8 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   getenv@2.0.0: {}
+
+  github-from-package@0.0.0: {}
 
   glob-parent@6.0.2:
     dependencies:
@@ -20479,6 +20578,8 @@ snapshots:
 
   mimic-fn@1.2.0: {}
 
+  mimic-response@3.1.0: {}
+
   miniflare@4.20260219.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -20519,6 +20620,8 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  mkdirp-classic@0.5.3: {}
+
   mkdirp@1.0.4: {}
 
   motion-dom@11.18.1:
@@ -20545,6 +20648,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
@@ -20557,6 +20662,10 @@ snapshots:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.8.1
+
+  node-abi@3.87.0:
+    dependencies:
+      semver: 7.7.3
 
   node-addon-api@2.0.2: {}
 
@@ -21038,6 +21147,21 @@ snapshots:
   preact@10.24.2: {}
 
   preact@10.28.2: {}
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.87.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
 
   prelude-ls@1.2.1: {}
 
@@ -21814,6 +21938,14 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   simple-plist@1.3.1:
     dependencies:
       bplist-creator: 0.1.0
@@ -22034,6 +22166,21 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar@7.5.7:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -22167,6 +22314,10 @@ snapshots:
       fsevents: 2.3.3
 
   tty-browserify@0.0.1: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,12 +266,6 @@ importers:
         specifier: ^0.19.1
         version: 0.19.1
     devDependencies:
-      '@types/better-sqlite3':
-        specifier: ^7.6.13
-        version: 7.6.13
-      better-sqlite3:
-        specifier: ^12.6.2
-        version: 12.6.2
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.9
@@ -16291,6 +16285,7 @@ snapshots:
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 25.0.10
+    optional: true
 
   '@types/connect@3.4.38':
     dependencies:
@@ -18335,6 +18330,7 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+    optional: true
 
   big-integer@1.6.36: {}
 
@@ -18359,6 +18355,7 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   blake-hash@2.0.0:
     dependencies:
@@ -18598,7 +18595,8 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  chownr@1.1.4: {}
+  chownr@1.1.4:
+    optional: true
 
   chownr@3.0.0: {}
 
@@ -18937,6 +18935,7 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+    optional: true
 
   deep-extend@0.6.0: {}
 
@@ -19401,7 +19400,8 @@ snapshots:
 
   exenv@1.2.2: {}
 
-  expand-template@2.0.3: {}
+  expand-template@2.0.3:
+    optional: true
 
   expo-asset@12.0.12(expo@54.0.33(@babel/core@7.28.6)(bufferutil@4.1.0)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.2.10)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(utf-8-validate@5.0.10))(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.2.10)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4):
     dependencies:
@@ -19656,7 +19656,8 @@ snapshots:
 
   fresh@0.5.2: {}
 
-  fs-constants@1.0.0: {}
+  fs-constants@1.0.0:
+    optional: true
 
   fs.realpath@1.0.0: {}
 
@@ -19703,7 +19704,8 @@ snapshots:
 
   getenv@2.0.0: {}
 
-  github-from-package@0.0.0: {}
+  github-from-package@0.0.0:
+    optional: true
 
   glob-parent@6.0.2:
     dependencies:
@@ -20578,7 +20580,8 @@ snapshots:
 
   mimic-fn@1.2.0: {}
 
-  mimic-response@3.1.0: {}
+  mimic-response@3.1.0:
+    optional: true
 
   miniflare@4.20260219.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
@@ -20620,7 +20623,8 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  mkdirp-classic@0.5.3: {}
+  mkdirp-classic@0.5.3:
+    optional: true
 
   mkdirp@1.0.4: {}
 
@@ -20648,7 +20652,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0: {}
+  napi-build-utils@2.0.0:
+    optional: true
 
   natural-compare@1.4.0: {}
 
@@ -20666,6 +20671,7 @@ snapshots:
   node-abi@3.87.0:
     dependencies:
       semver: 7.7.3
+    optional: true
 
   node-addon-api@2.0.2: {}
 
@@ -21162,6 +21168,7 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -21938,13 +21945,15 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
-  simple-concat@1.0.1: {}
+  simple-concat@1.0.1:
+    optional: true
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+    optional: true
 
   simple-plist@1.3.1:
     dependencies:
@@ -22172,6 +22181,7 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.3
       tar-stream: 2.2.0
+    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -22180,6 +22190,7 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   tar@7.5.7:
     dependencies:
@@ -22318,6 +22329,7 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
`drizzle-kit generate --custom`を実行し空のSQLとjsonを作成。
`migrations_archives/0002_seed_vaults.sql`の中身をcreateしたsqlにペースト、`0001_seed_vaults.sql`として保存しました。
その後`drizzle-kit migrate`を実行し、データの挿入を行いました。

※当初`better-sqlite3`関連のライブラリを用いて導入しようとしたためコミット記録にインストール記録が残っていますが、`better-sqlite3`がC++で記述されておりNode.js v24での事前ビルドバイナリが存在せず、実行できなかったためその後ライブラリの削除を行いました