### PR TITLE
ETF パフォーマンス計算 API 設計・実装

### DIFF
--- a/axis-api/src/routes/kagemusha.ts
+++ b/axis-api/src/routes/kagemusha.ts
@@ -8,11 +8,11 @@ import { Bindings } from '../config/env';
 import { StrategyGenerator } from '../services/strategy';
 import { PriceService } from '../services/price';
 import { JitoBundleService } from '../services/blockchain';
-import { 
-    Keypair, Connection, Transaction, PublicKey, 
-    ComputeBudgetProgram 
+import {
+    Keypair, Connection, Transaction, PublicKey,
+    ComputeBudgetProgram
 } from '@solana/web3.js';
-import { 
+import {
     getAssociatedTokenAddress, createAssociatedTokenAccountInstruction, createTransferInstruction 
 } from '@solana/spl-token';
 import bs58 from 'bs58';
@@ -463,6 +463,15 @@ app.get('/strategies/:id/chart', async (c) => {
     );
   }
   return c.json({ success: true, data, type });
+});
+
+app.get('/strategies/:id/performance', async (c) => {
+  try {
+    const id = c.req.param('id');
+    return c.json({success: true })
+  } catch (e: any) {
+    return c.json({ success: false, error: e.message }, 500);
+  }
 });
 
 app.get('/prepare-deployment', async (c) => {

--- a/axis-api/src/routes/kagemusha.ts
+++ b/axis-api/src/routes/kagemusha.ts
@@ -468,7 +468,63 @@ app.get('/strategies/:id/chart', async (c) => {
 app.get('/strategies/:id/performance', async (c) => {
   try {
     const id = c.req.param('id');
-    return c.json({success: true })
+
+    const baseline = await c.env.axis_db.prepare(
+      'SELECT baseline_price FROM strategy_deployment_baseline WHERE strategy_id = ?'
+    ).bind(id).first();
+
+    const current = await c.env.axis_db.prepare(
+      'SELECT index_price, confidence, ts_bucket_utc FROM strategy_price_snapshots WHERE strategy_id = ? ORDER BY ts_bucket_utc DESC LIMIT 1;'
+    ).bind(id).first();
+
+
+    const ago24h = await c.env.axis_db.prepare(
+      'SELECT index_price FROM strategy_price_snapshots WHERE strategy_id = ? AND ts_bucket_utc <= (unixepoch() - 86400) ORDER BY ts_bucket_utc DESC LIMIT 1;'
+    ).bind(id).first();
+
+    const ago7d = await c.env.axis_db.prepare(
+      'SELECT index_price FROM strategy_price_snapshots WHERE strategy_id = ? AND ts_bucket_utc <= (unixepoch() - 604800) ORDER BY ts_bucket_utc DESC LIMIT 1;'
+    ).bind(id).first();
+
+    if (!current) {
+      return c.json({
+        success: true,
+        current_price: null,
+        change_24h: null,
+        change_7d: null,
+        change_since_inception: null,
+        confidence: 'NO_DATA',
+        last_updated: null
+      });
+    } else if (!baseline || baseline.baseline_price === 0) {
+      return c.json({
+        success: true,
+        current_price: null,
+        change_24h: null,
+        change_7d: null,
+        change_since_inception: null,
+        confidence: 'FAIL',
+        last_updated: null
+      });
+    } else {
+      const currentNormalized = (current.index_price / baseline.baseline_price) * 100
+      const normalized24h = ago24h ? (ago24h.index_price / baseline.baseline_price) * 100 : null;
+      const normalized7d = ago7d ? (ago7d.index_price / baseline.baseline_price) * 100 : null;
+
+      const change_24h = normalized24h !== null ? ((currentNormalized - normalized24h) / normalized24h) * 100 : null;
+      const change_7d = normalized7d !== null ? ((currentNormalized - normalized7d) / normalized7d) * 100 : null;
+      const change_since_inception = currentNormalized - 100
+
+      return c.json({
+        success: true,
+        current_price: currentNormalized,
+        change_24h: change_24h,
+        change_7d: change_7d,
+        change_since_inception: change_since_inception,
+        confidence: ago24h && ago7d ? 'OK' : 'PARTIAL',
+        last_updated: current.ts_bucket_utc
+      });
+    }
   } catch (e: any) {
     return c.json({ success: false, error: e.message }, 500);
   }


### PR DESCRIPTION
kagemusha.tsに以下の内容を追記

- `GET /strategies/:id/performance` エンドポイントを新規追加。

- ETFのパフォーマンス指標(24h/7d/inception変動)をDBのスナップショットデータから算出して返す。

実装内容

- `strategy_price_snapshots`から現在・24h前・7d前の価格を取得
- `strategy_deployment_baseline` のbaseline価格を基準に正規化(baseline = 100)
- 各時点のchange%を算出
- データ不足・ゼロ除算などのエッジケースに対応(NO_DATA / FAIL / PARTIAL)