### PR TITLE
feat: スナップショット手動トリガーを追加

### DIFF
--- a/axis-api/src/routes/misc.ts
+++ b/axis-api/src/routes/misc.ts
@@ -5,6 +5,7 @@ import * as SolanaService from '../services/solana';
 import * as InviteModel from '../models/invite';
 import * as UserModel from '../models/user';
 import * as AuthService from '../services/auth';
+import { runPriceSnapshot } from '../services/snapshot';
 
 const app = new Hono<{ Bindings: Bindings }>();
 
@@ -203,6 +204,20 @@ app.post('/submit-bug', async (c) => {
     } catch (e: any) {
         console.error("Email Error:", e);
         return c.json({ success: false, message: `Failed to send email: ${e.message}` }, 500);
+    }
+});
+
+// スナップショット手動トリガー
+app.post('/admin/snapshot/trigger', async (c) => {
+try {
+        const startMs = Date.now()
+        const countResult = await c.env.axis_db.prepare('SELECT COUNT(*) as count FROM strategies').first();
+        const strategyCount = countResult?.count ?? 0;
+        await runPriceSnapshot( c.env.axis_db);
+
+        return c.json({ success: true, elapsed_ms: Date.now() - startMs, strategies: strategyCount })
+    } catch (e: any) {
+        return c.json({ success: false, error: e.message }, 500)
     }
 })
 


### PR DESCRIPTION
misc.tsに以下の内容を追記

- POST /admin/snapshot/trigger エンドポイントを新規追加。
   - Cronの動作確認および開発中に任意のタイミングでスナップショットを生成するための管理用エンドポイント。

実装内容
- `runPriceSnapshot(c.env.axis_db)` を呼び出しスナップショットを生成
- `SELECT COUNT(*) FROM strategies` で戦略数を取得し `strategies` フィールドで返す
- `Date.now()` で計測した経過時間を `elapsed_ms` フィールドで返す