### PR TITLE
Feat:chartline用エンドポイントのテストと実装

### DIFF
--- a/axis-api/src/app.ts
+++ b/axis-api/src/app.ts
@@ -10,7 +10,7 @@ import miscRoutes from './routes/misc';
 import kagemushaRoutes from './routes/kagemusha';
 import uploadRoutes from './routes/upload';
 import shareRoutes from './routes/share';
-import { chart } from './routes/chart';
+import { linechart } from './routes/chart';
 import { runPriceSnapshot } from './services/snapshot';
 import dflowRoutes from './routes/dflow';
 import mobileRoutes from './routes/mobile';
@@ -68,7 +68,7 @@ app.get('/init-db', async (c) => {
   }
 });
 
-app.get('/strategies/:id/linechart', chart);
+app.get('/strategies/:id/linechart', linechart);
 
 // --- Mount Routes ---
 app.route('/auth', authRoutes);

--- a/axis-api/src/app.ts
+++ b/axis-api/src/app.ts
@@ -10,6 +10,7 @@ import miscRoutes from './routes/misc';
 import kagemushaRoutes from './routes/kagemusha';
 import uploadRoutes from './routes/upload';
 import shareRoutes from './routes/share';
+import { chart } from './routes/chart';
 import { runPriceSnapshot } from './services/snapshot';
 import dflowRoutes from './routes/dflow';
 import mobileRoutes from './routes/mobile';
@@ -66,6 +67,8 @@ app.get('/init-db', async (c) => {
     return c.json({ success: false, error: e.message });
   }
 });
+
+app.get('/strategies/:id/linechart', chart);
 
 // --- Mount Routes ---
 app.route('/auth', authRoutes);

--- a/axis-api/src/routes/__tests__/endpoints/chartLine.test.ts
+++ b/axis-api/src/routes/__tests__/endpoints/chartLine.test.ts
@@ -1,0 +1,113 @@
+import { Hono } from 'hono';
+import { chart } from '../../chart.js';
+import type { Bindings } from '../../../config/env.js';
+
+// モックデータ
+// strategies テーブルのモックデータ
+const compositionRows = [
+    { id: 'strategy-123', composition: '[{"symbol":"SOL","weight":50,"logoURI":"...","address":"So11111111111111111111111111111111111111112"},{"symbol":"USDC","weight":50,"logoURI":"...","address":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}]' },
+];
+
+// token_price テーブルのモックデータ
+const tokenPriceRows = [
+    { token_name: 'SOL', recorded_at: '2026/03/19 10:00:00', price_usd: 60.0 },
+    { token_name: 'USDC', recorded_at: '2026/03/19 10:00:00', price_usd: 1.0 },
+    { token_name: 'SOL', recorded_at: '2026/03/19 10:05:00', price_usd: 59.0 },
+    { token_name: 'USDC', recorded_at: '2026/03/19 10:05:00', price_usd: 0.9 },
+];
+
+const mockDb = {
+    prepare: (sql: string) => ({
+        bind: (..._args: any[]) => ({
+            all: async () => {
+                if (sql.includes('strategies')) return { results: compositionRows };
+                if (sql.includes('token_prices')) return { results: tokenPriceRows };
+                return { results: [] };
+            },
+        }),
+    }),
+};
+
+// 計算結果のモックデータ
+const mockRows = [
+    { time: 1742378400, value: 30.5 },
+    { time: 1742378700, value: 29.95 },
+
+];
+
+// データがない場合のモックDB
+const emptyMockDb = {
+    prepare: (_sql: string) => ({
+        bind: (..._args: any[]) => ({
+            all: async () => ({ results: [] }),
+        }),
+    }),
+};
+
+// Hono アプリにルートを登録
+const app = new Hono<{ Bindings: Bindings }>()
+    .get('/:id/chart/line', chart);
+
+describe('GET /chart/line', () => {
+    // test.1 正常：id と period が両方指定されている
+    test('id と period が正しく指定された場合、データを返す', async () => {
+        const res = await app.request(
+            '/strategy-123/chart/line?period=7d',
+            {},
+            { axis_db: mockDb },
+        );
+        expect(res.status).toBe(200);
+        const json = await res.json() as { success: boolean; data: unknown[] };
+        expect(json.success).toBe(true);
+        expect(json.data).toEqual(mockRows);
+    });
+
+    // test.2 正常：period が指定されていない→7日で返す
+    test('period が指定されていない場合、デフォルトの7日分のデータを返す', async () => {
+        const res = await app.request(
+            '/strategy-123/chart/line',
+            {},
+            { axis_db: mockDb },
+        );
+        expect(res.status).toBe(200);
+        const json = await res.json() as { success: boolean; data: unknown[] };
+        expect(json.success).toBe(true);
+        expect(json.data).toEqual(mockRows);
+    });
+
+    // test.3 異常：id が空→404を返す
+    test('id が空の場合、404を返す', async () => {
+        const res = await app.request(
+            '/chart/line?period=7d',
+            {},
+            { axis_db: mockDb },
+        );
+        expect(res.status).toBe(404);
+    });
+
+    // test.4 異常：token_priceの1部が空→あるデータのみで計算して返す
+    test('token_priceの1部が空の場合、あるデータのみで計算して返す', async () => {
+        const res = await app.request(
+            '/strategy-123/chart/line?period=7d',
+            {},
+            { axis_db: emptyMockDb },
+        );
+        expect(res.status).toBe(200);
+        const json = await res.json() as { success: boolean; data: unknown[] };
+        expect(json.success).toBe(true);
+        expect(json.data).toEqual([]);
+    });
+
+    // test.5 異常：token_priceの全てが空→計算結果が空の配列になる
+    test('DBにデータが全くない場合、空配列を返す', async () => {
+        const res = await app.request(
+            '/strategy-123/chart/line?period=7d',
+            {},
+            { axis_db: emptyMockDb },
+        );
+        expect(res.status).toBe(200);
+        const json = await res.json() as { success: boolean; data: unknown[] };
+        expect(json.success).toBe(true);
+        expect(json.data).toEqual([]);
+    });
+});

--- a/axis-api/src/routes/__tests__/endpoints/chartLine.test.ts
+++ b/axis-api/src/routes/__tests__/endpoints/chartLine.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { chart } from '../../chart.js';
+import { linechart } from '../../chart.js';
 import type { Bindings } from '../../../config/env.js';
 
 
@@ -83,7 +83,7 @@ const emptyTokenPriceMockRows : any[] = [];
 
 // Hono アプリにルートを登録
 const app = new Hono<{ Bindings: Bindings }>()
-    .get('/:id/linechart', chart);
+    .get('/:id/linechart', linechart);
 
 
 describe('GET /strategies/:id/linechart', () => {

--- a/axis-api/src/routes/__tests__/endpoints/chartLine.test.ts
+++ b/axis-api/src/routes/__tests__/endpoints/chartLine.test.ts
@@ -83,14 +83,14 @@ const emptyTokenPriceMockRows : any[] = [];
 
 // Hono アプリにルートを登録
 const app = new Hono<{ Bindings: Bindings }>()
-    .get('/:id/chart/line', chart);
+    .get('/:id/linechart', chart);
 
 
-describe('GET /chart/line', () => {
+describe('GET /strategies/:id/linechart', () => {
     // test.1 正常：id と period が両方指定されている
     test('id と period が正しく指定された場合、データを返す', async () => {
         const res = await app.request(
-            '/strategy-123/chart/line?period=7d',
+            '/strategy-123/linechart?period=7d',
             {},
             { axis_db: mockDb },
         );
@@ -107,7 +107,7 @@ describe('GET /chart/line', () => {
     // test.2 正常：period が指定されていない→7日で返す
     test('period が指定されていない場合、デフォルトの7日分のデータを返す', async () => {
         const res = await app.request(
-            '/strategy-123/chart/line',
+            '/strategy-123/linechart',
             {},
             { axis_db: mockDb },
         );
@@ -124,7 +124,7 @@ describe('GET /chart/line', () => {
     // test.3 異常：id が空→404を返す
     test('id が空の場合、404を返す', async () => {
         const res = await app.request(
-            '/chart/line?period=7d',
+            '/linechart?period=7d',
             {},
             { axis_db: mockDb },
         );
@@ -136,7 +136,7 @@ describe('GET /chart/line', () => {
     // test.4 異常：token_priceの1部が空→あるデータのみで計算して返す
     test('token_priceの1部が空の場合、あるデータのみで計算して返す', async () => {
         const res = await app.request(
-            '/strategy-123/chart/line?period=7d',
+            '/strategy-123/linechart?period=7d',
             {},
             { axis_db: partialMockDb },
         );
@@ -153,7 +153,7 @@ describe('GET /chart/line', () => {
     // test.5 異常：token_priceの全てが空→計算結果が空の配列になる
     test('DBにデータが全くない場合、空配列を返す', async () => {
         const res = await app.request(
-            '/strategy-123/chart/line?period=7d',
+            '/strategy-123/linechart?period=7d',
             {},
             { axis_db: emptyMockDb },
         );

--- a/axis-api/src/routes/__tests__/endpoints/chartLine.test.ts
+++ b/axis-api/src/routes/__tests__/endpoints/chartLine.test.ts
@@ -2,20 +2,9 @@ import { Hono } from 'hono';
 import { chart } from '../../chart.js';
 import type { Bindings } from '../../../config/env.js';
 
+
 // モックデータ
-// strategies テーブルのモックデータ
-const compositionRows = [
-    { id: 'strategy-123', composition: '[{"symbol":"SOL","weight":50,"logoURI":"...","address":"So11111111111111111111111111111111111111112"},{"symbol":"USDC","weight":50,"logoURI":"...","address":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}]' },
-];
-
-// token_price テーブルのモックデータ
-const tokenPriceRows = [
-    { token_name: 'SOL', recorded_at: '2026/03/19 10:00:00', price_usd: 60.0 },
-    { token_name: 'USDC', recorded_at: '2026/03/19 10:00:00', price_usd: 1.0 },
-    { token_name: 'SOL', recorded_at: '2026/03/19 10:05:00', price_usd: 59.0 },
-    { token_name: 'USDC', recorded_at: '2026/03/19 10:05:00', price_usd: 0.9 },
-];
-
+// モックDB
 const mockDb = {
     prepare: (sql: string) => ({
         bind: (..._args: any[]) => ({
@@ -28,14 +17,20 @@ const mockDb = {
     }),
 };
 
-// 計算結果のモックデータ
-const mockRows = [
-    { time: 1742378400, value: 30.5 },
-    { time: 1742378700, value: 29.95 },
+// token_price の一部データがないケースのモックDB
+const partialMockDb = {
+    prepare: (sql: string) => ({
+        bind: (..._args: any[]) => ({
+            all: async () => {
+                if (sql.includes('strategies')) return { results: compositionRows };
+                if (sql.includes('token_prices')) return { results: partialTokenPriceRows };
+                return { results: [] };
+            },
+        }),
+    }),
+};
 
-];
-
-// データがない場合のモックDB
+// token_price の全てのデータがないケースのモックDB
 const emptyMockDb = {
     prepare: (_sql: string) => ({
         bind: (..._args: any[]) => ({
@@ -44,9 +39,52 @@ const emptyMockDb = {
     }),
 };
 
+
+// strategies テーブルのモックデータ
+const compositionRows = [
+    { id: 'strategy-123', composition: '[{"symbol":"SOL","weight":50,"logoURI":"...","address":"So11111111111111111111111111111111111111112"},{"symbol":"USDC","weight":50,"logoURI":"...","address":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}]' },
+];
+
+// token_price テーブルのモックデータ
+const tokenPriceRows = [
+    { token_name: 'SOL', recorded_at: '2026-03-19T10:00:00Z', price_usd: 60.0 },
+    { token_name: 'USDC', recorded_at: '2026-03-19T10:00:00Z', price_usd: 1.0 },
+    { token_name: 'SOL', recorded_at: '2026-03-19T10:05:00Z', price_usd: 59.0 },
+    { token_name: 'USDC', recorded_at: '2026-03-19T10:05:00Z', price_usd: 0.9 },
+
+    // 8日以上過去のデータ
+    { token_name: 'SOL', recorded_at: '2026-03-10T10:00:00Z', price_usd: 55.0 },
+    { token_name: 'USDC', recorded_at: '2026-03-10T10:00:00Z', price_usd: 1.0 },
+    { token_name: 'SOL', recorded_at: '2026-03-10T10:05:00Z', price_usd: 54.0 },
+    { token_name: 'USDC', recorded_at: '2026-03-10T10:05:00Z', price_usd: 1.0 },
+];
+
+// token_price の一部データがないケース(今回USDCが欠損)
+const partialTokenPriceRows = [
+    { token_name: 'SOL', recorded_at: '2026-03-19T10:00:00Z', price_usd: 60.0 },
+    { token_name: 'SOL', recorded_at: '2026-03-19T10:05:00Z', price_usd: 59.0 },
+];
+
+// 正常時の計算結果のモックデータ
+const mockRows = [
+    { time: 1773914400, value: 30.5 },
+    { time: 1773914700, value: 29.95 },
+];
+
+// 異常：token_priceの一部が空のケースの計算結果のモックデータ
+const partialTokenPriceMockRows = [
+    { time: 1773914400, value: 30.0 },
+    { time: 1773914700, value: 29.5 },
+];
+
+// 異常：token_priceの全てが空のケースの計算結果のモックデータ
+const emptyTokenPriceMockRows : any[] = [];
+
+
 // Hono アプリにルートを登録
 const app = new Hono<{ Bindings: Bindings }>()
     .get('/:id/chart/line', chart);
+
 
 describe('GET /chart/line', () => {
     // test.1 正常：id と period が両方指定されている
@@ -58,6 +96,10 @@ describe('GET /chart/line', () => {
         );
         expect(res.status).toBe(200);
         const json = await res.json() as { success: boolean; data: unknown[] };
+        console.log('=== expected ===');
+        console.log(JSON.stringify(mockRows, null, 2));
+        console.log('=== actual ===');
+        console.log(JSON.stringify(json.data, null, 2));
         expect(json.success).toBe(true);
         expect(json.data).toEqual(mockRows);
     });
@@ -71,6 +113,10 @@ describe('GET /chart/line', () => {
         );
         expect(res.status).toBe(200);
         const json = await res.json() as { success: boolean; data: unknown[] };
+        console.log('=== expected ===');
+        console.log(JSON.stringify(mockRows, null, 2));
+        console.log('=== actual ===');
+        console.log(JSON.stringify(json.data, null, 2));
         expect(json.success).toBe(true);
         expect(json.data).toEqual(mockRows);
     });
@@ -83,6 +129,8 @@ describe('GET /chart/line', () => {
             { axis_db: mockDb },
         );
         expect(res.status).toBe(404);
+        console.log('=== actual status ===');
+        console.log(res.status);
     });
 
     // test.4 異常：token_priceの1部が空→あるデータのみで計算して返す
@@ -90,12 +138,16 @@ describe('GET /chart/line', () => {
         const res = await app.request(
             '/strategy-123/chart/line?period=7d',
             {},
-            { axis_db: emptyMockDb },
+            { axis_db: partialMockDb },
         );
         expect(res.status).toBe(200);
         const json = await res.json() as { success: boolean; data: unknown[] };
+        console.log('=== expected ===');
+        console.log(JSON.stringify(partialTokenPriceMockRows, null, 2));
+        console.log('=== actual ===');
+        console.log(JSON.stringify(json.data, null, 2));
         expect(json.success).toBe(true);
-        expect(json.data).toEqual([]);
+        expect(json.data).toEqual(partialTokenPriceMockRows);
     });
 
     // test.5 異常：token_priceの全てが空→計算結果が空の配列になる
@@ -107,7 +159,11 @@ describe('GET /chart/line', () => {
         );
         expect(res.status).toBe(200);
         const json = await res.json() as { success: boolean; data: unknown[] };
+        console.log('=== expected ===');
+        console.log(JSON.stringify(emptyTokenPriceMockRows, null, 2));
+        console.log('=== actual ===');
+        console.log(JSON.stringify(json.data, null, 2));
         expect(json.success).toBe(true);
-        expect(json.data).toEqual([]);
+        expect(json.data).toEqual(emptyTokenPriceMockRows);
     });
 });

--- a/axis-api/src/routes/chart.ts
+++ b/axis-api/src/routes/chart.ts
@@ -33,7 +33,7 @@ export async function chart(c: Context<{ Bindings: Bindings }>) {
     }
 
     // token_prices テーブルから基準日時以降のデータを取得
-    const tokenNamesResult = await db.prepare('SELECT token_name, recorded_at, price_usd FROM token_prices WHERE recorded_at >= ?').bind(fromDate).all();
+    const tokenNamesResult = await db.prepare('SELECT token_name, recorded_at, price_usd FROM token_prices WHERE recorded_at >= ?').bind(fromDate.toISOString()).all();
     const filteredRows = tokenNamesResult.results.filter((row: any) => new Date(String(row.recorded_at)) >= fromDate);
 
     // 取得したデータを recorded_at ごとに token_name と price_usd をマッピング

--- a/axis-api/src/routes/chart.ts
+++ b/axis-api/src/routes/chart.ts
@@ -2,7 +2,7 @@ import { Context } from 'hono';
 import { Bindings } from '../config/env.js';
 
 // チャートデータを返すエンドポイント
-export async function chart(c: Context<{ Bindings: Bindings }>) {
+export async function linechart(c: Context<{ Bindings: Bindings }>) {
     const id = c.req.param('id');
 
     // strategyからcomposition(銘柄と比率)を取得

--- a/axis-api/src/routes/chart.ts
+++ b/axis-api/src/routes/chart.ts
@@ -1,0 +1,65 @@
+import { Context } from 'hono';
+import { Bindings } from '../config/env.js';
+
+// チャートデータを返すエンドポイント
+export async function chart(c: Context<{ Bindings: Bindings }>) {
+    const id = c.req.param('id');
+
+    // strategyからcomposition(銘柄と比率)を取得
+    const db = c.env.axis_db;
+    const compositionResult = await db.prepare('SELECT composition FROM strategies WHERE id = ?').bind(id).all();
+    if (!compositionResult.results.length) {
+        return c.json({ success: true, data: [] });
+    }
+    const composition = JSON.parse(compositionResult.results[0].composition);
+
+    // period(記録期間)の取得とパース
+    const period = c.req.query('period') ?? '7d'
+
+    // periodの形式に応じて基準日時を計算
+    const now = new Date();
+    let fromDate: Date;
+    // dateの場合は日数を引く
+    if (period.endsWith('d')) {
+        const days = parseInt(period.slice(0, -1));
+        fromDate = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+    // hourの場合は時間を引く
+    } else if (period.endsWith('h')) {
+        const hours = parseInt(period.slice(0, -1));
+        fromDate = new Date(now.getTime() - hours * 60 * 60 * 1000);
+    // 形式が不正な場合はエラーを返す
+    } else {
+        return c.json({ success: false, message: 'format is invalid' });
+    }
+
+    // token_prices テーブルから基準日時以降のデータを取得
+    const tokenNamesResult = await db.prepare('SELECT token_name, recorded_at, price_usd FROM token_prices WHERE recorded_at >= ?').bind(fromDate).all();
+    const filteredRows = tokenNamesResult.results.filter((row: any) => new Date(String(row.recorded_at)) >= fromDate);
+
+    // 取得したデータを recorded_at ごとに token_name と price_usd をマッピング
+    const priceMap = new Map();
+    const data: { time: number; value: number }[] = []
+
+    for (const row of filteredRows) {
+        if (!priceMap.has(row.recorded_at)) {
+            priceMap.set(row.recorded_at, new Map());
+        }
+        priceMap.get(row.recorded_at).set(row.token_name, row.price_usd);
+    }
+
+    // recorded_at ごとにチャートの値を計算
+    for (const [recorded_at, tokenPrices] of priceMap) {
+        let value = 0;
+        for (const { symbol, weight } of composition) {
+            const price = tokenPrices.get(symbol);
+            if (price) {
+                value += price * weight / 100;
+            }
+        }
+
+        // Unix秒に変換
+        const time = Math.floor(new Date(recorded_at).getTime() / 1000);
+        data.push({ time, value })
+    }
+    return c.json({ success: true, data })
+}


### PR DESCRIPTION
chartline用エンドポイントを作成するためにTDDを実施、以下のファイルを作成した。
 - `axis-api/src/routes/chart.ts` ... `/strategies/:id/linechart` エンドポイントの実装。ストラテジーのcompositionと価格データからチャート用時系列データを生成。`period`クエリパラメータ(`7d`/`h`形式)でフィルタリングする 
 - `axis-api/src/routes/__tests__/endpoints/chartLine.test.ts` ... `chart.ts`の動作確認用テストファイル。

またAPIエンドポイント実装に伴い、`app.ts`に`app.get('/strategies/:id/linechart', linechart);`を追記した。