### PR TITLE
feat: fix X share URL to use /strategy/:id

### DIFF
--- a/axis-agent/src/Home.tsx
+++ b/axis-agent/src/Home.tsx
@@ -73,15 +73,29 @@ export default function Home() {
 
   const handleConnectWallet = () => { openLogin(true); };
 
+  // Handle browser back button when on strategy detail
+  useEffect(() => {
+    const onPopState = () => {
+      if (view === 'STRATEGY_DETAIL') {
+        setView(previousView);
+        setSelectedStrategy(null);
+      }
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, [view, previousView]);
+
   const handleStrategySelect = (strategy: Strategy) => {
     setPreviousView(view);
     setSelectedStrategy(strategy);
     setView('STRATEGY_DETAIL');
+    window.history.pushState(null, '', `/strategy/${strategy.id}`);
   };
 
   const handleBackFromDetail = () => {
     setView(previousView);
     setSelectedStrategy(null);
+    window.history.pushState(null, '', '/');
   };
 
   const navigateTo = useCallback((newView: View) => {

--- a/axis-agent/src/components/discover/StrategyDetailView.tsx
+++ b/axis-agent/src/components/discover/StrategyDetailView.tsx
@@ -506,8 +506,9 @@ export const StrategyDetailView = ({ initialData, onBack }: StrategyDetailViewPr
 
   const handleShareToX = () => {
     const text = `Check out ${strategy.name} ($${strategy.ticker}) on Axis! 🚀`;
+    const shareUrl = `${window.location.origin}/strategy/${strategy.id}`;
     window.open(
-      `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(window.location.href)}`,
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(shareUrl)}`,
       '_blank'
     );
   };


### PR DESCRIPTION
## Summary

- `handleShareToX` が `window.location.href`（常に `/`）を使っていたのを `origin/strategy/{id}` に修正
- ストラテジー詳細を開いたとき `history.pushState` で URL を `/strategy/:id` に更新
- 戻るときは `/` に戻す
- ブラウザの戻るボタンに対応する `popstate` ハンドラを追加

## Test plan

- [ ] ストラテジー詳細を開いてアドレスバーが `/strategy/:id` になることを確認
- [ ] 「Share on X」ボタンを押して、ツイート文のURLが `/strategy/:id` になっていることを確認
- [ ] ブラウザの戻るボタンでトップに戻ることを確認

> Note: OGPの動的生成はバックエンド対応が必要なため別PRで対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)