### PR TITLE
chore: DBスキーマ整理とtoken_pricesテーブル内 recorded_atをISO形式への変換

### DIFF
--- a/axis-api/README.md
+++ b/axis-api/README.md
@@ -19,3 +19,18 @@ Pass the `CloudflareBindings` as generics when instantiation `Hono`:
 // src/index.ts
 const app = new Hono<{ Bindings: CloudflareBindings }>()
 ```
+
+// Drizzle ORMを用いたmigrationsによるDB管理の流れ
+``` txt
+// 1. migrationsファイルの作成
+// schema.ts の変更を検知して新しいSQLファイルを生成する
+pnpm drizzle-kit generate
+
+// 2. ローカルのD1データベースへの適用(開発・テスト用)
+// 作成したSQLをローカル環境のDBに反映させる
+pnpm wrangler d1 migrations apply <db_name> --local
+
+// 3. 本番のCloudflare D1へのDeploy(本番環境への適用)
+// テストが終わったSQLを本番環境のDBに反映させる
+pnpm wrangler d1 migrations apply <db_name> --remote
+```

--- a/axis-api/migrations/0003_add_strategies_columns.sql
+++ b/axis-api/migrations/0003_add_strategies_columns.sql
@@ -1,5 +1,0 @@
-ALTER TABLE `strategies` ADD `composition` text;
-ALTER TABLE `strategies` ADD `tvl` real;
-ALTER TABLE `strategies` ADD `roi` real;
-ALTER TABLE `strategies` ADD `mint_address` text;
-ALTER TABLE `strategies` ADD `vault_address` text;

--- a/axis-api/migrations/0003_update_token_prices.sql
+++ b/axis-api/migrations/0003_update_token_prices.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_token_prices` (
+	`token_name` text NOT NULL,
+	`recorded_at` text NOT NULL,
+	`price_usd` real,
+	PRIMARY KEY(`token_name`, `recorded_at`)
+);
+--> statement-breakpoint
+INSERT INTO `__new_token_prices`("token_name", "recorded_at", "price_usd") SELECT "token_name", "recorded_at", "price_usd" FROM `token_prices`;--> statement-breakpoint
+DROP TABLE `token_prices`;--> statement-breakpoint
+ALTER TABLE `__new_token_prices` RENAME TO `token_prices`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+ALTER TABLE `strategies` ADD `composition` text;--> statement-breakpoint
+ALTER TABLE `strategies` ADD `tvl` real;--> statement-breakpoint
+ALTER TABLE `strategies` ADD `roi` real;--> statement-breakpoint
+ALTER TABLE `strategies` ADD `mint_address` text;--> statement-breakpoint
+ALTER TABLE `strategies` ADD `vault_address` text;--> statement-breakpoint
+ALTER TABLE `users` ADD `bio` text;--> statement-breakpoint
+ALTER TABLE `users` ADD `badges` text;--> statement-breakpoint
+ALTER TABLE `users` ADD `total_xp` integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE `users` ADD `rank_tier` text DEFAULT 'Novice';--> statement-breakpoint
+ALTER TABLE `users` ADD `pnl_percent` real DEFAULT 0;--> statement-breakpoint
+ALTER TABLE `users` ADD `last_checkin` integer DEFAULT 0;

--- a/axis-api/migrations/meta/0003_snapshot.json
+++ b/axis-api/migrations/meta/0003_snapshot.json
@@ -1,0 +1,835 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "520e4957-9e33-449c-b93b-5788d32c73f7",
+  "prevId": "bdbce4f7-cf87-4bb1-a183-90dfe70524ad",
+  "tables": {
+    "invites": {
+      "name": "invites",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_by_user_id": {
+          "name": "used_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategies": {
+      "name": "strategies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_pubkey": {
+          "name": "owner_pubkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "composition": {
+          "name": "composition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jito_bundle_id": {
+          "name": "jito_bundle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_deposited": {
+          "name": "total_deposited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tvl": {
+          "name": "tvl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "roi": {
+          "name": "roi",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mint_address": {
+          "name": "mint_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vault_address": {
+          "name": "vault_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_deployment_baseline": {
+      "name": "strategy_deployment_baseline",
+      "columns": {
+        "strategy_id": {
+          "name": "strategy_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "baseline_ts_bucket_utc": {
+          "name": "baseline_ts_bucket_utc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "baseline_price": {
+          "name": "baseline_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "baseline_confidence": {
+          "name": "baseline_confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strategy_price_snapshots": {
+      "name": "strategy_price_snapshots",
+      "columns": {
+        "strategy_id": {
+          "name": "strategy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ts_bucket_utc": {
+          "name": "ts_bucket_utc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "index_price": {
+          "name": "index_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prices_json": {
+          "name": "prices_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weights_json": {
+          "name": "weights_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_json": {
+          "name": "source_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "strategy_price_snapshots_strategy_id_ts_bucket_utc_pk": {
+          "columns": [
+            "strategy_id",
+            "ts_bucket_utc"
+          ],
+          "name": "strategy_price_snapshots_strategy_id_ts_bucket_utc_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "token_prices": {
+      "name": "token_prices",
+      "columns": {
+        "token_name": {
+          "name": "token_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_usd": {
+          "name": "price_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "token_prices_token_name_recorded_at_pk": {
+          "columns": [
+            "token_name",
+            "recorded_at"
+          ],
+          "name": "token_prices_token_name_recorded_at_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "twitter_id": {
+          "name": "twitter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_code_used": {
+          "name": "invite_code_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badges": {
+          "name": "badges",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_code": {
+          "name": "otp_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_expires": {
+          "name": "otp_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rank_tier": {
+          "name": "rank_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Novice'"
+        },
+        "pnl_percent": {
+          "name": "pnl_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_checkin": {
+          "name": "last_checkin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_faucet_at": {
+          "name": "last_faucet_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_invested_usd": {
+          "name": "total_invested_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_snapshot_at": {
+          "name": "last_snapshot_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_wallet_address_unique": {
+          "name": "users_wallet_address_unique",
+          "columns": [
+            "wallet_address"
+          ],
+          "isUnique": true
+        },
+        "users_invite_code_unique": {
+          "name": "users_invite_code_unique",
+          "columns": [
+            "invite_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vaults": {
+      "name": "vaults",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_type": {
+          "name": "strategy_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "management_fee": {
+          "name": "management_fee",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_liquidity": {
+          "name": "min_liquidity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "composition": {
+          "name": "composition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tvl": {
+          "name": "tvl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "apy": {
+          "name": "apy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watchlist": {
+      "name": "watchlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "strategy_id": {
+          "name": "strategy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xp_ledger": {
+      "name": "xp_ledger",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_pubkey": {
+          "name": "user_pubkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_id": {
+          "name": "related_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xp_rates": {
+      "name": "xp_rates",
+      "columns": {
+        "strategy_id": {
+          "name": "strategy_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_rate": {
+          "name": "base_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xp_snapshots": {
+      "name": "xp_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_pubkey": {
+          "name": "user_pubkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy_id": {
+          "name": "strategy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capped_usd": {
+          "name": "capped_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_processed": {
+          "name": "is_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/axis-api/migrations/meta/_journal.json
+++ b/axis-api/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1772089490956,
       "tag": "0002_create_token_prices",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1775644150299,
+      "tag": "0003_update_token_prices",
+      "breakpoints": true
     }
   ]
 }

--- a/axis-api/scripts/convert_recorded_at_to_iso.sql
+++ b/axis-api/scripts/convert_recorded_at_to_iso.sql
@@ -1,0 +1,3 @@
+-- 現在YYYY/MM/DD HH:mm:ssの形式で保存されているcreated_atをYYYY-MM-DDTHH:mm:ssZの形式に変換
+
+UPDATE token_prices SET recorded_at = REPLACE(REPLACE(recorded_at, '/', '-'), ' ', 'T') || '.000Z';

--- a/axis-api/src/db/schema.ts
+++ b/axis-api/src/db/schema.ts
@@ -1,4 +1,25 @@
-import { int, integer, primaryKey, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { int, integer, primaryKey, real, sqliteTable, text, customType } from "drizzle-orm/sqlite-core";
+
+// ──────────────────────────────────────────────────────────
+// DBの型定義とテーブルスキーマ
+// （Drizzle ORMを使用してSQLiteのテーブルを定義）
+// ──────────────────────────────────────────────────────────
+// Drizzleのカスタム型：ISO 8601形式の日時をDBに保存するための型変換ロジック
+const customTimestamp = customType<
+    {
+        data: Date; // TypeScript上の型
+        driverData: string; // DB上の型
+    }
+>({
+    // DB上の型
+    dataType: (): string => "text",
+
+    // TypeScript -> DBの変換
+    toDriver: (value: Date): string => value.toISOString(),
+
+    // DB -> TypeScriptの変換
+    fromDriver: (value: string): Date => new Date(value),
+});
 
 // ──────────────────────────────────────────────────────────
 // ユーザー（認証・プロフィール・投資サマリー）
@@ -159,7 +180,7 @@ export const strategyDeploymentBaselineTable = sqliteTable("strategy_deployment_
 // ──────────────────────────────────────────────────────────
 export const strategyTokenPricesTable = sqliteTable("token_prices", {
     token_name:   text("token_name").notNull(),
-    recorded_at:  text("recorded_at").notNull(),
+    recorded_at:  customTimestamp( "recorded_at" ).notNull(),
     price_usd:    real("price_usd"),
 }, (t) => [
     primaryKey({ columns: [t.token_name, t.recorded_at] }),

--- a/axis-api/src/services/snapshot/index.ts
+++ b/axis-api/src/services/snapshot/index.ts
@@ -58,15 +58,8 @@ export async function runPriceSnapshot(db: any): Promise<void> {
 
   // 3. Batch fetch all prices (deduplicated by mint)
   const priceMap = await fetchPrices([...allMints]);
-  // 価格取得時刻を YYYY/MM/DD HH:MM:SS 形式で記録
-  const _now = new Date();
-  const priceFetchedAt =
-    `${_now.getUTCFullYear()}/` +
-    `${String(_now.getUTCMonth() + 1).padStart(2, '0')}/` +
-    `${String(_now.getUTCDate()).padStart(2, '0')} ` +
-    `${String(_now.getUTCHours()).padStart(2, '0')}:` +
-    `${String(_now.getUTCMinutes()).padStart(2, '0')}:` +
-    `${String(_now.getUTCSeconds()).padStart(2, '0')}`;
+  // 価格取得時刻をISO 8601形式で記録
+  const priceFetchedAt = new Date().toISOString();
 
   // 4. Build snapshot statements
   const snapshotStmts: any[] = [];


### PR DESCRIPTION
## 概要

DBメンテナンスとして、以下の対応を行いました。

## 変更内容

### 1. READMEにmigrations運用手順を追記

### 2. Migrationsファイルの再生成
- 本番環境未反映だった旧 `0003_add_strategies_columns.sql` を削除
- Drizzle ORM で改めて generate し直した `0003_update_token_prices.sql` に置き換え
  - `token_prices` テーブルの再作成(型の整合性修正)
  - `strategies` への列追加(`composition`, `tvl`, `roi`, `mint_address`, `vault_address`)
  - `users` への列追加(`bio`, `badges`, `total_xp`, `rank_tier`, `pnl_percent`, `last_checkin`)
  - ※上記三点の変更について、users テーブルと strategies テーブルについて、0003_update_token_prices.sql 上は複数のカラムが追加されるはずだが、そちらの変更に関しては既に別で行われている。
また今回のメインである token_prices テーブルに置ける recorded_atに関して、Drizzleのcustomを使用した時間記録形式に変更したが、DB上では変わらず text ととして扱われる。
そのため migrations の反映後、本番環境には表面上何も変更がないと予想されます。

### 3. `token_prices内 recorded_at` のISO形式対応
- `snapshot/index.ts` で `priceFetchedAt` の生成を `new Date().toISOString()` に変更
  - 従来: `2026/04/08 03:15:30` 形式
  - 変更後: `2026-04-08T03:15:30.000Z` 形式

### 4. 既存データの変換スクリプト追加
- `scripts/convert_recorded_at_to_iso.sql`：既存の `recorded_at` を旧形式からISOへ変換するUPDATE文を作成



