### PR TITLE
perf(ogp): write-through edge cache + memoize font to beat Twitterbot timeout

### DIFF
--- a/axis-api/src/routes/share.tsx
+++ b/axis-api/src/routes/share.tsx
@@ -25,7 +25,12 @@ const app = new Hono<{ Bindings: Bindings }>();
 
 
 // Use old Firefox UA to get WOFF (v1) — satori uses opentype.js which doesn't support WOFF2
+const fontCache = new Map<string, ArrayBuffer>();
 const loadFont = async (family: string, weight: string = '400;700') => {
+  const key = `${family}:${weight}`;
+  const hit = fontCache.get(key);
+  if (hit) return hit;
+
   const css = await fetch(
     `https://fonts.googleapis.com/css2?family=${family}:wght@${weight}&display=swap`,
     { headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 5.1; rv:23.0) Gecko/20100101 Firefox/23.0' } }
@@ -35,7 +40,9 @@ const loadFont = async (family: string, weight: string = '400;700') => {
     ?? css.match(/url\(([^)]+\.woff)\)/)?.[1];
   if (!fontUrl) throw new Error(`No WOFF font URL in CSS: ${css.slice(0, 200)}`);
 
-  return fetch(fontUrl).then(r => r.arrayBuffer());
+  const buf = await fetch(fontUrl).then(r => r.arrayBuffer());
+  fontCache.set(key, buf);
+  return buf;
 };
 
 function bufToBase64(buf: ArrayBuffer): string {
@@ -159,6 +166,13 @@ function generateLineChart(
 // 1. Strategy OGP image endpoint
 app.get('/strategy-image/:id', async (c) => {
   try {
+    // Serve from edge cache if available — a raw Cache-Control header alone
+    // is NOT enough in Workers; we have to put/match the Cache API ourselves.
+    const cache = caches.default;
+    const cacheKey = new Request(c.req.url, { method: 'GET' });
+    const cached = await cache.match(cacheKey);
+    if (cached) return cached;
+
     const id = c.req.param('id');
 
     const row = await c.env.axis_db.prepare(
@@ -318,10 +332,19 @@ app.get('/strategy-image/:id', async (c) => {
     );
 
     const png = await svgToPng(svg);
-    return c.body(png, 200, {
-      'Content-Type': 'image/png',
-      'Cache-Control': 'public, max-age=3600',
+    const response = new Response(png, {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/png',
+        'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+      },
     });
+
+    // Write-through to edge cache so subsequent requests (especially
+    // Twitterbot's) skip the 2-5s regeneration entirely.
+    c.executionCtx.waitUntil(cache.put(cacheKey, response.clone()));
+
+    return response;
   } catch (e: any) {
     return c.json({ error: e?.message || String(e), stack: e?.stack?.slice(0, 300) }, 500);
   }


### PR DESCRIPTION
## Problem

OGP cards weren't generating on X even though `/share/strategy/:id` returned valid OGP HTML. Measured response times on the image endpoint:

- **1st (cold)**: 5.55s
- **2nd (warm)**: 1.88s
- `CF-Cache-Status` header **missing entirely**

Twitterbot's scraping budget is ~3–5s, so it times out before the image is generated. Even second requests from X are too slow.

## Root cause

A `Cache-Control` response header **does not** make Cloudflare Workers responses cache at the edge. Workers have to use the Cache API (`caches.default.match` / `put`) explicitly.

## Fix

1. **Write-through edge cache** on `/share/strategy-image/:id`. First hit still takes 5s, but every subsequent hit globally becomes a ~50ms CDN HIT (until `max-age` expires). Strategy-image cache keys are effectively unique per strategy id, so there's no cross-id leak.
2. **Memoize the Google Fonts Lora woff fetch** in module scope, so even cache-miss requests on the same isolate don't re-hit Google Fonts (saves ~200–400ms on warm cold-starts, matches the pattern already used in `JupiterService`).
3. `s-maxage=86400` in `Cache-Control` so the edge keeps the PNG longer than the browser — strategies are effectively immutable for OGP purposes.

## Test plan

- [ ] Deploy axis-api (`cd axis-api && pnpm deploy`)
- [ ] `curl -w "%{time_total}\n"` against `/share/strategy-image/:id` twice:
  - 1st call: ~5s, returns 200
  - 2nd call: <200ms, `CF-Cache-Status: HIT` in headers
- [ ] Post a fresh URL (with `?v=2` to dodge X's stale-no-preview cache) to X → large image card should appear
- [ ] Verify nothing else regressed: strategies with no composition still render; unknown tokens still show fallback circles

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8WJJDK6S5pGNM8w4Fc7VW)_